### PR TITLE
Fixes issues in the MapPin script that prevented updating a MapPin's Location at runtime

### DIFF
--- a/SupportingScripts/Runtime/Scripts/MapRenderer/MapPin/MapPin.cs
+++ b/SupportingScripts/Runtime/Scripts/MapRenderer/MapPin/MapPin.cs
@@ -4,14 +4,13 @@
 namespace Microsoft.Maps.Unity
 {
     using Microsoft.Geospatial;
-    using Microsoft.Geospatial.VectorMath;
     using System;
     using System.Collections.Generic;
     using UnityEngine;
 
     /// <summary>
     /// A MapPin can be used to pin a <see cref="GameObject"/> to a <see cref="MapRendererBase"/> at a specified
-    /// <see cref="Geospatial.LatLon"/> and altitude.
+    /// <see cref="LatLon"/> and altitude in meters.
     /// </summary>
     [DisallowMultipleComponent]
     [ExecuteInEditMode]
@@ -36,20 +35,20 @@ namespace Microsoft.Maps.Unity
                 if (value != oldLocation)
                 {
                     _location = new LatLonWrapper(value);
-                    LocationChanged?.Invoke(this, value);
+                    MercatorCoordinate = _location.ToLatLon().ToMercatorCoordinate();
+                    LocationChanged?.Invoke(this, oldLocation); // Invoke action with the MapPin and old location.
                 }
             }
         }
 
         /// <summary>
-        /// Action that is invoked when the <see cref="Location"/> is changed.
+        /// <see cref="Action"/> that is invoked when the <see cref="Location"/> value has changed.
+        /// The <see cref="LatLon"/> specified in the arguments is the previous location.
         /// </summary>
         public Action<MapPin, LatLon> LocationChanged;
 
-        private MercatorCoordinate _mercatorCoordinate;
-
         /// <inheritdoc/>
-        public MercatorCoordinate MercatorCoordinate => _mercatorCoordinate;
+        public MercatorCoordinate MercatorCoordinate { get; private set; }
 
         [SerializeField]
         private double _altitude;
@@ -99,7 +98,7 @@ namespace Microsoft.Maps.Unity
         /// </summary>
         protected virtual void Reset()
         {
-            _mercatorCoordinate = Location.ToMercatorCoordinate();
+            MercatorCoordinate = Location.ToMercatorCoordinate();
         }
 
         /// <summary>
@@ -107,7 +106,7 @@ namespace Microsoft.Maps.Unity
         /// </summary>
         protected virtual void Awake()
         {
-            _mercatorCoordinate = Location.ToMercatorCoordinate();
+            MercatorCoordinate = Location.ToMercatorCoordinate();
         }
 
         /// <summary>
@@ -115,20 +114,20 @@ namespace Microsoft.Maps.Unity
         /// </summary>
         protected virtual void OnEnable()
         {
-            _mercatorCoordinate = Location.ToMercatorCoordinate();
+            MercatorCoordinate = Location.ToMercatorCoordinate();
         }
 
         /// <summary>
         /// This method is called when the script is loaded or a value is changed in the inspector. Called in the editor only.
         /// </summary>
-        protected virtual void Validate()
+        protected virtual void OnValidate()
         {
-            _mercatorCoordinate = Location.ToMercatorCoordinate();
+            MercatorCoordinate = Location.ToMercatorCoordinate();
         }
 
         /// <summary>
         /// Synchronizes the <see cref="MapPin"/>'s layers (and any of it's children layers) with the <see cref="MapRenderer"/>'s layer.
-        /// Whether or not a <see cref="MapPin"/>'s layer is synchronized depends on the value of <see cref="MapPin.IsLayerSynchronized"/>.
+        /// Whether or not a <see cref="MapPin"/>'s layer is synchronized depends on the value of <see cref="IsLayerSynchronized"/>.
         /// </summary>
         public static void SynchronizeLayers(IReadOnlyList<MapPin> mapPins, MapRenderer mapRenderer)
         {
@@ -147,7 +146,7 @@ namespace Microsoft.Maps.Unity
         }
 
         /// <summary>
-        ///  Updates the <see cref="MapPin"/>s' scale based on <see cref="MapPin.ScaleCurve"/> and <see cref="MapPin.UseRealWorldScale"/>.
+        ///  Updates the <see cref="MapPin"/>s' scale based on <see cref="ScaleCurve"/> and <see cref="UseRealWorldScale"/>.
         /// </summary>
         public static void UpdateScales<T>(List<T> mapPins, MapRenderer mapRenderer) where T : MapPin
         {
@@ -159,7 +158,7 @@ namespace Microsoft.Maps.Unity
 
             foreach (var mapPin in mapPins)
             {
-                if (mapPin.enabled && mapPin.gameObject.activeInHierarchy)
+                if (mapPin.enabled) // Skip MapPins that aren't enabled.
                 {
                     // Scale the pin depending on the scale curve and current ZoomLevel.
                     var mercatorScaleAtCoordinate = MercatorScale.AtMercatorLatitude(mapPin.MercatorCoordinate.Y);


### PR DESCRIPTION
Fixes:
* Changing the Location property should update MercatorCoordinate property. This is the main fix.
* Validate() should be renamed to OnValidate(). This enables changes to the MapPin inspector to immediately update MapPins childed to a MapRenderer.
* The LocationChanged event should be invoked with the old location (not the new location). This allows clusters to be updated correctly.

The rest of the changes are minor cleanup.